### PR TITLE
Resolve App Service Import Acceptance test failure

### DIFF
--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -23,9 +23,9 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration"},
 			},
 		},

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -23,9 +23,10 @@ func TestAccAzureRMAppService_importBasic(t *testing.T) {
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_dns_registration", "skip_custom_domain_verification", "skip_dns_registration"},
 			},
 		},
 	})


### PR DESCRIPTION
This is to resolve Import App Service Resource Acceptance test failure. Failure is shown below.

```
$ TF_ACC=1  ARM_TEST_LOCATION=southcentralus ARM_TEST_LOCATION_ALT=eastus  go test ./azurerm/ -run TestAccAzureRMAppService_importBasic  -v -timeout=20m
=== RUN   TestAccAzureRMAppService_importBasic
--- FAIL: TestAccAzureRMAppService_importBasic (78.80s)
        testing.go:435: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

                (map[string]string) {
                }


                (map[string]string) (len=3) {
                 (string) (len=22) "force_dns_registration": (string) (len=5) "false",
                 (string) (len=31) "skip_custom_domain_verification": (string) (len=4) "true",
                 (string) (len=21) "skip_dns_registration": (string) (len=4) "true"
                }
```

To get around this failure "force_dns_registration", "skip_custom_domain_verification" and  "skip_dns_registration" were added to ImportStateVerifyIgnore.

Acceptance test successful after change 
```
TF_ACC=1  ARM_TEST_LOCATION=southcentralus ARM_TEST_LOCATION_ALT=eastus  go test ./azurerm/ -run TestAccAzureRMAppService_importBasic  -v -timeout=20m
=== RUN   TestAccAzureRMAppService_importBasic
--- PASS: TestAccAzureRMAppService_importBasic (90.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       90.217s
```